### PR TITLE
modify zlib archive url

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ new_http_archive(
     build_file = "zlib.BUILD",
     sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
     strip_prefix = "zlib-1.2.8",
-    url = "http://zlib.net/zlib-1.2.8.tar.gz",
+    url = "http://zlib.net/fossils/zlib-1.2.8.tar.gz",
 )
 
 git_repository(


### PR DESCRIPTION
zlib-1.2.8.tar.gz is moved under http://zlib.net/fossils/